### PR TITLE
Add proper command line argument parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Please follow the instructions below to build the SILVER framework:
 6. `make release`
 
 ## Quick Start
-Build the SILVER framework using the instructions above. You can configure the framework in `/inc/config.hpp` to specify the number of cores and RAM used by Sylvan. Besides, you can enable Verilog parsing or parse instruction files directly (cf. examples in `test/`). If Verilog parsing is enabled, please specify necessary parameters in `/inc/config.hpp` and describe your cell library used during synthesis in `cell/` (example given for constrained NANG45).
+Build the SILVER framework using the instructions above. You can configure the framework via the [command line](#Command-line-options) to specify the number of cores and RAM used by Sylvan. Besides, you can enable Verilog parsing or parse instruction files directly (cf. examples in `test/`). If Verilog parsing is enabled, please specify necessary parameters in `/inc/config.hpp` and describe your cell library used during synthesis in `cell/` (example given for constrained NANG45).
 
 1. `make release`
 2. `./bin/verify`
 
-Examplary output for `/test/dom/dom1.nl` (instruction file) with `VERBOSE 1`:
+Examplary output for `/test/dom/dom1.nl` (instruction file) with `--verbose=1`:
 
 ```
 [     0.000] Netlist: test/dom/dom1.nl
@@ -45,6 +45,38 @@ Examplary output for `/test/dom/dom1.nl` (instruction file) with `VERBOSE 1`:
 [     0.007] PINI.robust      (d ≤ 1) -- FAIL.  >> Probes: <reg:line14>
 [     0.007] uniformity               -- PASS.
 ```
+
+## Command line options
+
+The following shows the main command line options to the program:
+
+```sh
+$> ./bin/verify --help
+Silver arguments:
+  --help                                Show the help message
+  --cores arg (=0)                      Maximum number of CPU cores to use. Set
+                                        to 0 (default) for auto-detect
+  --memory arg (=1073741824)            RAM (in Bytes) used by Sylvan BDD 
+                                        library.
+  --verbose arg (=0)                    Be verbose (or not) in printing 
+                                        detailed test reports.
+  --verilog arg (=0)                    Parse the verilog design described by 
+                                        the --verilog-* parameters.
+  --verilog-libfile arg (=cell/Library.txt)
+                                        Technology library description.
+  --verilog-libname arg (=NANG45)       Technology library name.
+  --verilog-design_file arg (=vlog/aes/AES_Sbox_DOM/2-Synthesized/aes_sbox_dom1.v)
+                                        Verilg source file containing the 
+                                        design.
+  --verilog-module_name arg (=aes_sbox) Module contained within the verilog 
+                                        source to verify.
+  --insfile arg (=test/aes/aes_sbox_dom1.nl)
+                                        Instruction list to parse and process. 
+                                        Either externally provided or result of
+                                        verilog parser
+```
+
+Note that if you do not set `--verilog=1` then all other `--verilog-*` arguments will be ignored.
 
 ## Verilog annotations
 
@@ -147,6 +179,8 @@ In case you get an error message similar to:
 ```
 
 please export the `/lib` directory to your linker library path, e.g., using `export LD_LIBRARY_PATH=``pwd``/lib` before executing the binary.
+
+Note that you may get a similar error referring to `libboost_program_options.so`. You will need to add the path to your boost installation to `LD_LIBRARY_PATH`. E.g. `export LD_LIBRARY_PATH=$BOOST/lib:$LD_LIBRARY_PATH`.
 
 ### Cache creation (memory allocation)
 In case you get an error message similar to: 

--- a/inc/config.hpp
+++ b/inc/config.hpp
@@ -29,25 +29,28 @@
 #include <sylvan/sylvan.h>
 #include <sylvan/sylvan_obj.hpp>
 
+/* Contains all configuration options for the Silver verify tool. */
+typedef struct silver_config {
+
 /* Specify number of cores (0 for auto-detect) and RAM (in Byte) used by Sylvan BDD library */
-#define CORES 0
-#define MEMORY 1*1024*1024*1024ull
+unsigned int CORES;
+size_t       MEMORY;
 
-/* Enable (1) / disable (0) detailed test reporting */
-#define VERBOSE 1
+/* Enable (true) / disable (false) detailed test reporting */
+bool         VERBOSE;
 
-/* Enable (defined) / disable (undefined) verilog design parsing */
-#define VERILOG
+/* Enable (true) / disable (false) verilog design parsing */
+bool         PARSE_VERILOG;
 
 /* Instruction list (either externally provided or result of verilog parser) */
-#define INSFILE "test/aes/aes_sbox_dom1.nl"
+std::string INSFILE ;
 
-/* If VERILOG is defined, specify verilog design details here */
-#ifdef VERILOG
-#define LIBFILE "cell/Library.txt"
-#define LIBNAME "NANG45"
-#define DESIGN  "vlog/aes/AES_Sbox_DOM/2-Synthesized/aes_sbox_dom1.v"
-#define MODULE  "aes_sbox"
-#endif
+/* If PARSE_VERILOG is set, specify verilog design details here */
+std::string LIBFILE;
+std::string LIBNAME;
+std::string DESIGN;
+std::string MODULE;
+
+} silver_config_t;
 
 #endif // __SILVER_CONFIG_HPP_

--- a/makefile
+++ b/makefile
@@ -1,5 +1,9 @@
+
+BOOST    ?= /home/work/tools/boost_1_71_0/install
+SYLVAN	 := "./inc/sylvan"
+
 CXX 	 := g++
-CXXFLAGS := -m64 -march=native
+CXXFLAGS := -m64 -march=native -DVERILOG
 LDFLAGS  := -m64
 
 TARGET	 := verify
@@ -14,10 +18,7 @@ INC_DIR  := ./inc
 LIB_DIR	 := ./lib
 OBJ_DIR	 := $(BLD_DIR)/objects
 
-BOOST    := "/mnt/c/Program Files/boost/boost_1_71_0"
-SYLVAN	 := "./inc/sylvan"
-
-LIBRARIES:= -L$(LIB_DIR) -lsylvan
+LIBRARIES:= -L$(LIB_DIR) -lsylvan  -L$(BOOST)/lib -lboost_program_options
 
 # SOURCES  := $(wildcard $(SRC_DIR)/*.cpp)
 SOURCES  := $(shell find $(SRC_PATH) -name '*.$(SRC_EXT)' | sort -k 1nr | cut -f2-)


### PR DESCRIPTION
Hi there

First off, awesome project. Thank you for your detailed instructions on building things!

This pull request replaces the hard-coded defines in `inc/confg.hpp` with a structure, and allows them to be updated with command line arguments. The struct fields remain the same where appropriate.

The boost program_options library is used to add proper argument parsing in `src/verify.cpp`. I figured this was reasonable, since boost is already a project dependency.

I've kept the default run behaviour of the program the same, but now one can specify how many cores / how much memory / which files to ingest via the command line, which makes the whole tool much easier to use.

The makefile has been changed in three significant ways:

- The BOOST variable is assigned with ?= rather than :=. This allows it to be  set from the environment or command line without changing the makefile.

- the VERILOG define is always present, since one can parse verilog (or not)  based on the `--verilog=0/1` command line flag.

- The `boost_program_options` library and search paths are included in the build.

The readme has been updated with the command line arguments, including where they are relevant to examples and the gottcha for including the `boost` libs directory in the `LD_LIBRARY_PATH`.

I know this pull request is out of the blue. I hope it isn't too controversial. I'd like to be able to use your tool in more automated design/verification flows on different modules, and this change enables that. Please let me know if it can be improved upon. I'm very happy iterating on it if need be.

Many thanks,
Ben